### PR TITLE
Update dub.json

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -19,6 +19,6 @@
 	}
 	],
 	"dependencies": {
-		"libdparse": "~>0.7.0-alpha10"
+		"libdparse": "~>0.8.0-alpha.1"
 	}
 }


### PR DESCRIPTION
```d
/+ dub.sdl:
    dependency "libdparse" version="~>0.8.0-alpha.1"
    dependency "dsymbol" version="~>0.3.0-alpha.1"
    dependency "libddoc" version="*"
    name "dub_script" +/
module dub_script;

void main(string[] args)
{}
```

> Could not find a valid dependency tree configuration: Dependency libddoc -> libdparse >=0.7.0-alpha10 <0.8.0-0 mismatches with selected version 0.8.0-alpha.1
error: the process (/usr/bin/dub) has returned the signal 512

DUB wants all the packages to use the same version of a dep. This is why my last D-Scanner PR fails when build with DUB.